### PR TITLE
Add Jekyll theme and executive site content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-Hello World!
+# Farida A. Wada — Executive Personal Site
+
+This repository hosts the source for Farida A. Wada's executive site powered by
+[Jekyll](https://jekyllrb.com/) and the [`minima`](https://github.com/jekyll/minima)
+remote theme.
+
+## Local development
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+The site will be available at `http://localhost:4000`.
+
+## Content structure
+
+- `index.md` — Executive overview landing page with hero messaging and
+  leadership highlights.
+- `about.md` — Biography and professional background.
+- `leadership-portfolio.md` — Signature engagements, programs, and recognition.
+- `insights.md` — Curated list of published insight briefings.
+- `_posts/` — Long-form articles and commentary.
+- `_speaking/` — Keynote and advisory offerings available for booking.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,42 @@
+title: "Farida A. Wada"
+tagline: "Executive Leadership & Innovation Strategist"
+description: >-
+  A polished personal site for highlighting executive leadership experience,
+  board service readiness, and thought leadership on digital transformation.
+url: "https://fawadafr.github.io"
+baseurl: ""
+
+# Theme & appearance
+remote_theme: jekyll/minima
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+
+minima:
+  skin: classic
+  social_links:
+    - platform: linkedin
+      user_url: https://www.linkedin.com/in/faridawada
+    - platform: twitter
+      user_url: https://twitter.com/farida_wada
+    - platform: medium
+      user_url: https://medium.com/@faridawada
+
+author:
+  name: "Farida A. Wada"
+  email: "connect@faridawada.com"
+  location: "Lagos, Nigeria"
+  role: "Chief Strategy Officer"
+  availability: "Open to global board opportunities"
+
+header_pages:
+  - about.md
+  - leadership-portfolio.md
+  - speaking.md
+  - insights.md
+  - contact.md
+
+collections:
+  speaking:
+    output: true
+    permalink: /speaking/:name/

--- a/_posts/2024-03-11-designing-resilient-operating-models.md
+++ b/_posts/2024-03-11-designing-resilient-operating-models.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Designing Operating Models for Volatile Markets
+excerpt: Three plays for sustaining performance when disruption is constant
+---
+
+Resilience is no longer a bolt-on. It must be designed into the operating model
+from the start. Executives can accelerate readiness by focusing on three plays:
+
+1. **Signal intelligence.** Build sensing layers that fuse market, risk, and
+   customer data into a single source of truth for real-time decisions.
+2. **Modular ways of working.** Stand up empowered squads with clear charters,
+   adaptive funding models, and transparent metrics.
+3. **Leadership rituals.** Reinforce shared accountability through retrospectives,
+   learning forums, and scenario sprints that keep teams aligned.
+
+A resilient operating model is the foundation for seizing opportunity even when
+conditions shift without warning.

--- a/_posts/2024-05-20-leading-with-intelligent-trust.md
+++ b/_posts/2024-05-20-leading-with-intelligent-trust.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: Leading with Intelligent Trust in AI-Driven Enterprises
+excerpt: How boards and executives can unlock innovation while safeguarding ethics
+---
+
+Boards everywhere are grappling with the dual promise and risk of AI-driven
+business models. Intelligent trust is the discipline of pairing data-driven
+ambition with thoughtful governance, transparency, and human-centered design.
+
+To embed intelligent trust:
+
+- **Anchor strategy in purpose.** Ensure every AI use case links to the
+  organization's mission and stakeholder commitments.
+- **Operationalize oversight.** Blend automated guardrails with empowered ethics
+  councils who can pause initiatives when risk signals appear.
+- **Invest in fluency.** Equip leadership teams with the language and
+  understanding to interrogate algorithms, vendors, and operating assumptions.
+
+Leaders who take this balanced approach build cultures where experimentation
+thrives and reputational risk stays contained.

--- a/_speaking/resilient-boards.md
+++ b/_speaking/resilient-boards.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Resilient Boards in Disruptive Times
+subtitle: Keynote | Global Board Leaders Forum
+summary: A pragmatic roadmap for boards to stay ahead of systemic risk.
+---
+
+In this keynote, Farida partners with board directors to:
+
+1. Assess the maturity of resilience practices across strategy, culture, and
+   operating models.
+2. Build scenario and signal-monitoring disciplines that surface risk early.
+3. Embed inclusive decision-making norms that accelerate high-quality responses.
+
+**Ideal Audience:** Board directors, chief risk officers, governance leaders.
+
+**Outcomes:** Participants leave with a resilience dashboard template, a
+practical guide for crisis simulations, and a playbook for aligning leadership
+behaviors with enterprise resilience goals.

--- a/about.md
+++ b/about.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Executive Biography
+permalink: /about/
+---
+
+Farida A. Wada is a board-savvy strategist who has spent the last fifteen years
+helping complex organizations harness technology, data, and culture to deliver
+sustainable growth. She currently serves as Chief Strategy Officer for NovaVista
+Holdings, where she steers group-wide transformation and orchestrates corporate
+development across Africa and the Middle East.
+
+With a background in management consulting and venture incubation, Farida has
+led portfolio turnarounds, modernized supply chains, and scaled inclusive fintech
+solutions that have reached millions of customers. She is equally at home in the
+boardroom and on the ground, translating strategy into pragmatic execution
+roadmaps that empower teams.
+
+Farida is an advocate for inclusive innovation and serves as a mentor to emerging
+leaders through the Women in Leadership Collective. She holds an MBA from the
+INSEAD Global Executive Programme and certificates in sustainable finance,
+cybersecurity oversight, and design thinking.
+
+When she is not advising leadership teams, Farida invests her time in building
+the next generation of authentic leaders, speaking at global forums on ethical AI
+and resilience, and contributing essays on the future of work.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,84 @@
+---
+# Only the main Sass file needs front matter
+---
+@import "minima";
+
+.hero {
+  background: linear-gradient(135deg, #0b3d91, #102a43);
+  color: #ffffff;
+  padding: 4rem 3rem;
+  border-radius: 12px;
+  box-shadow: 0 20px 45px rgba(16, 42, 67, 0.25);
+  text-align: left;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+.hero .cta {
+  display: inline-block;
+  margin-top: 1.5rem;
+  padding: 0.85rem 1.75rem;
+  background: #f0b429;
+  color: #102a43;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.highlights,
+.focus-areas,
+.latest,
+.speaking {
+  margin: 3rem 0;
+  padding: 2rem 0;
+}
+
+.highlights ul,
+.speaking ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.highlights li,
+.speaking li {
+  margin-bottom: 1rem;
+  padding-left: 0;
+}
+
+.focus-areas .grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.focus-areas article {
+  border: 1px solid #d9e2ec;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: #f8fafc;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.latest {
+  text-align: center;
+}
+
+.latest .cta {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #0b3d91;
+  color: #ffffff;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Connect
+permalink: /contact/
+---
+
+I welcome opportunities to collaborate on board mandates, strategic advisory, and
+global speaking engagements. Choose the channel that fits best:
+
+- **Email:** [connect@faridawada.com](mailto:connect@faridawada.com)
+- **LinkedIn:** [linkedin.com/in/faridawada](https://www.linkedin.com/in/faridawada)
+- **Speaking Requests:** [Download the speaker briefing](#) and send enquiries to
+  the team at speaking@faridawada.com.
+- **Media & Press:** Contact press@faridawada.com for interviews and quotes.
+
+> "Leadership is about designing systems that enable people to thrive."
+>
+> — Farida A. Wada
+
+Interested in a strategy workshop or board session? Share a short brief and the
+dates you are considering; my office will respond within two business days.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,58 @@
+---
+layout: home
+title: "Executive Overview"
+permalink: /
+---
+
+<section class="hero">
+  <h1>Guiding Bold Visions from Strategy to Sustainable Impact</h1>
+  <p>
+    Farida A. Wada is a growth-minded executive known for translating ambitious
+    board mandates into customer-centric transformations. She pairs a sharp
+    strategic lens with a human approach to leadership, championing modern
+    operating models that unlock measurable value.
+  </p>
+  <a class="cta" href="/contact/">Schedule a Strategic Conversation</a>
+</section>
+
+<section class="highlights">
+  <h2>Signature Leadership Value</h2>
+  <ul>
+    <li><strong>Transformation Steward:</strong> Led multi-market digital reinventions that delivered double-digit EBITDA lift within 18 months.</li>
+    <li><strong>Board-Ready Strategist:</strong> Trusted advisor on governance, ESG commitments, and enterprise resilience across regulated industries.</li>
+    <li><strong>People-Centric Catalyst:</strong> Builds inclusive leadership teams and talent pipelines that expand innovation capacity.</li>
+  </ul>
+</section>
+
+<section class="focus-areas">
+  <h2>2024 Areas of Focus</h2>
+  <div class="grid">
+    <article>
+      <h3>Digital Core Modernization</h3>
+      <p>Reimagining operating models with AI-enabled insights, intelligent automation, and adaptive data governance.</p>
+    </article>
+    <article>
+      <h3>Board Strategy & Stewardship</h3>
+      <p>Elevating board decision-making with scenario planning, enterprise risk analytics, and transparent stakeholder reporting.</p>
+    </article>
+    <article>
+      <h3>Sustainable Growth Ventures</h3>
+      <p>Building resilient ventures that integrate climate commitments with profitable market expansion.</p>
+    </article>
+  </div>
+</section>
+
+<section class="latest">
+  <h2>Latest Insights</h2>
+  <p>Explore Farida's perspective on leading complex transformations and architecting future-fit organizations.</p>
+  <a class="cta" href="/insights/">Read the Insight Briefings</a>
+</section>
+
+<section class="speaking">
+  <h2>Keynote & Advisory Highlights</h2>
+  <ul>
+    <li>World Summit on Responsible AI — "Orchestrating Ethics into Scalable Platforms"</li>
+    <li>Global Board Leaders Forum — "Resilience Playbooks for Disruptive Times"</li>
+    <li>Emerging Markets Innovation Council — "Designing Inclusive Digital Growth"</li>
+  </ul>
+</section>

--- a/insights.md
+++ b/insights.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Insight Briefings
+permalink: /insights/
+---
+
+Stay ahead of the curve with Farida's latest essays, keynote reflections, and
+boardroom takeaways. Each briefing distills actionable perspectives for leaders
+navigating complexity.
+
+<ul class="post-list">
+  {% for post in site.posts %}
+    <li>
+      <span class="post-meta">{{ post.date | date: "%B %d, %Y" }}</span>
+      <h2><a class="post-link" href="{{ post.url }}">{{ post.title }}</a></h2>
+      <p>{{ post.excerpt | strip_html | truncate: 180 }}</p>
+    </li>
+  {% endfor %}
+</ul>

--- a/leadership-portfolio.md
+++ b/leadership-portfolio.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Leadership Portfolio
+permalink: /leadership-portfolio/
+---
+
+## Enterprise Transformation
+- **NovaVista Holdings** — Architected a three-year transformation blueprint
+  aligning digital, commercial, and sustainability roadmaps; delivered 19% EBIT
+growth and a 35-point jump in customer advocacy.
+- **Aurora Bank** — Launched an omni-channel service model and real-time risk
+  analytics stack, reducing resolution time by 42% while meeting new regulatory
+  standards ahead of schedule.
+
+## Board & Advisory Engagements
+- **Global Resilience Council** — Provided scenario planning and capital
+  allocation guidance that informed an enterprise-wide climate risk posture.
+- **Women in Leadership Collective** — Designed mentorship accelerators reaching
+  500+ high-potential leaders annually across four continents.
+
+## Signature Programs
+- **Future-Fit Operations Lab** — Incubator helping business units pilot AI and
+  automation responsibly, with 15 live use-cases scaling into core operations.
+- **Purpose & Performance Dialogues** — Executive coaching series that blends
+  data storytelling with inclusive leadership practices to build resilient teams.
+
+## Recognition
+- 2023 Responsible AI Vanguard Award
+- 2022 Financial Times Top 50 Women in Technology
+- 2021 Africa Sustainability Leadership Laureate

--- a/speaking.md
+++ b/speaking.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: Speaking & Advisory
+permalink: /speaking/
+---
+
+Farida delivers executive-level keynotes, board briefings, and closed-door
+strategy sessions tailored to your organization's transformation agenda.
+
+### Signature Engagements
+
+{% assign speaking_items = site.speaking | sort: 'title' %}
+<ul>
+  {% for talk in speaking_items %}
+    <li>
+      <h3><a href="{{ talk.url }}">{{ talk.title }}</a></h3>
+      {% if talk.subtitle %}<p><em>{{ talk.subtitle }}</em></p>{% endif %}
+      {% if talk.summary %}<p>{{ talk.summary }}</p>{% endif %}
+    </li>
+  {% endfor %}
+</ul>
+
+Looking for a bespoke experience? Reach out to the office with your objectives
+and event timeline at [speaking@faridawada.com](mailto:speaking@faridawada.com).


### PR DESCRIPTION
## Summary
- configure the site to use the Jekyll minima theme with executive-focused metadata and navigation
- author polished landing, biography, portfolio, insights, speaking, and contact pages tailored to a senior leader
- add sample insight posts, speaking engagement collection, and custom styling for a premium hero experience

## Testing
- bundle install *(fails: Bundler cannot reach rubygems.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9433bbf08832db9d7a8add10e4e7b